### PR TITLE
Added a possibility of reading configuration from app.config/web.config

### DIFF
--- a/src/Ninject.Extensions.Xml/Configuration/NinjectSectionHandler.cs
+++ b/src/Ninject.Extensions.Xml/Configuration/NinjectSectionHandler.cs
@@ -1,0 +1,50 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="IXmlAttributeProcessor.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Ilya Verbitskiy (iverbitskiy@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+#if !SILVERLIGHT && !WINDOWS_PHONE && !WINRT
+
+using System.Configuration;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Ninject.Extensions.Xml.Configuration
+{
+    /// <summary>
+    /// Handles configuration sections that contains Ninject modules definition.
+    /// </summary>
+    public class NinjectSectionHandler : IConfigurationSectionHandler
+    {
+        /// <summary>
+        /// Creates a configuration section handler.
+        /// </summary>
+        /// <param name="parent">Parent object.</param>
+        /// <param name="configContext">Configuration context object.</param>
+        /// <param name="section">Section XML node.</param>
+        /// <returns>XDocument representing NInject modules.</returns>
+        public object Create(object parent, object configContext, XmlNode section)
+        {
+            var reader = new XmlNodeReader(section);
+            return XDocument.Load(reader);
+        }
+    }
+}
+
+#endif

--- a/src/Ninject.Extensions.Xml/Configuration/NinjectSectionHandler.cs
+++ b/src/Ninject.Extensions.Xml/Configuration/NinjectSectionHandler.cs
@@ -30,19 +30,25 @@ namespace Ninject.Extensions.Xml.Configuration
     /// <summary>
     /// Handles configuration sections that contains Ninject modules definition.
     /// </summary>
-    public class NinjectSectionHandler : IConfigurationSectionHandler
+    public class NinjectSectionHandler : ConfigurationSection
     {
         /// <summary>
-        /// Creates a configuration section handler.
+        /// Ninject modules configuration.
         /// </summary>
-        /// <param name="parent">Parent object.</param>
-        /// <param name="configContext">Configuration context object.</param>
-        /// <param name="section">Section XML node.</param>
-        /// <returns>XDocument representing NInject modules.</returns>
-        public object Create(object parent, object configContext, XmlNode section)
+        public XDocument NinjectModules
         {
-            var reader = new XmlNodeReader(section);
-            return XDocument.Load(reader);
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Reads XML from the configuration file.
+        /// </summary>
+        /// <param name="reader">The XmlReader that reads from the configuration file.</param>
+        /// <param name="serializeCollectionKey">true to serialize only the collection key properties; otherwise, false.</param>
+        protected override void DeserializeElement(XmlReader reader, bool serializeCollectionKey)
+        {
+            NinjectModules = XDocument.Load(reader);
         }
     }
 }

--- a/src/Ninject.Extensions.Xml/Extensions/ExtensionsForKernel.cs
+++ b/src/Ninject.Extensions.Xml/Extensions/ExtensionsForKernel.cs
@@ -26,6 +26,7 @@ using System.Configuration;
 using System.Linq;
 using System.Xml.Linq;
 using Ninject.Extensions.Xml;
+using Ninject.Extensions.Xml.Configuration;
 using Ninject.Extensions.Xml.Processors;
 using Ninject.Modules;
 
@@ -43,8 +44,8 @@ namespace Ninject
         /// <param name="sectionName">Application Configuration File section name with modules definition.</param>
         public static void LoadFromConfiguration(this IKernel kernel, string sectionName)
         {
-            var ninjectSection = (XDocument)ConfigurationManager.GetSection(sectionName);
-            var modules = GetModules(kernel, ninjectSection);
+            var ninjectSection = (NinjectSectionHandler)ConfigurationManager.GetSection(sectionName);
+            var modules = GetModules(kernel, ninjectSection.NinjectModules);
             kernel.Load(modules);
         }
 

--- a/src/Ninject.Extensions.Xml/Extensions/ExtensionsForKernel.cs
+++ b/src/Ninject.Extensions.Xml/Extensions/ExtensionsForKernel.cs
@@ -1,0 +1,68 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="IXmlAttributeProcessor.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Ilya Verbitskiy (iverbitskiy@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+#if !SILVERLIGHT && !WINDOWS_PHONE && !WINRT
+
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Xml.Linq;
+using Ninject.Extensions.Xml;
+using Ninject.Extensions.Xml.Processors;
+using Ninject.Modules;
+
+namespace Ninject
+{
+    /// <summary>
+    /// Extension methods for IKernel
+    /// </summary>
+    public static class ExtensionsForKernel
+    {
+        /// <summary>
+        /// Load Ninject modules from Application Configuration File.
+        /// </summary>
+        /// <param name="kernel">Ninject kernel.</param>
+        /// <param name="sectionName">Application Configuration File section name with modules definition.</param>
+        public static void LoadFromConfiguration(this IKernel kernel, string sectionName)
+        {
+            var ninjectSection = (XDocument)ConfigurationManager.GetSection(sectionName);
+            var modules = GetModules(kernel, ninjectSection);
+            kernel.Load(modules);
+        }
+
+        /// <summary>
+        /// Gets the modules.
+        /// </summary>
+        /// <param name="kernel">Ninject kernel.</param>
+        /// <param name="document">XDocument with modules definition.</param>
+        /// <returns>The modules found by this module loader.</returns>
+        private static IEnumerable<INinjectModule> GetModules(IKernel kernel, XDocument document)
+        {
+            var elementProcessors = kernel.Components.GetAll<IModuleChildXmlElementProcessor>()
+                                          .ToDictionary(processor => processor.XmlNodeName);
+
+            return (from moduleElement in document.Root.Elements("module")
+                    select new XmlModule(moduleElement, elementProcessors)).Cast<INinjectModule>();
+        }
+    }
+}
+
+#endif

--- a/src/Ninject.Extensions.Xml/Extensions/ExtensionsForKernel.cs
+++ b/src/Ninject.Extensions.Xml/Extensions/ExtensionsForKernel.cs
@@ -37,14 +37,21 @@ namespace Ninject
     /// </summary>
     public static class ExtensionsForKernel
     {
+        private const string SectionName = "ninject";
+
         /// <summary>
         /// Load Ninject modules from Application Configuration File.
         /// </summary>
         /// <param name="kernel">Ninject kernel.</param>
-        /// <param name="sectionName">Application Configuration File section name with modules definition.</param>
-        public static void LoadFromConfiguration(this IKernel kernel, string sectionName)
+        public static void LoadFromConfiguration(this IKernel kernel)
         {
-            var ninjectSection = (NinjectSectionHandler)ConfigurationManager.GetSection(sectionName);
+            var ninjectSection = (NinjectSectionHandler)ConfigurationManager.GetSection(SectionName);
+            if (ninjectSection == null)
+            {
+                var error = string.Format("{0} configuration section is not found.", SectionName);
+                throw new ConfigurationErrorsException(error);
+            }
+
             var modules = GetModules(kernel, ninjectSection.NinjectModules);
             kernel.Load(modules);
         }

--- a/src/Ninject.Extensions.Xml/Ninject.Extensions.Xml.csproj
+++ b/src/Ninject.Extensions.Xml/Ninject.Extensions.Xml.csproj
@@ -79,6 +79,8 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Configuration\NinjectSectionHandler.cs" />
+    <Compile Include="Extensions\ExtensionsForKernel.cs" />
     <Compile Include="Extensions\ExtensionsForDictionary.cs" />
     <Compile Include="Extensions\ExtensionsForXElement.cs" />
     <Compile Include="Processors\AbstractXmlAttributeProcessor.cs" />


### PR DESCRIPTION
This is the fix for https://github.com/ninject/Ninject.Extensions.Xml/issues/2 feature request. I have added a possibility to save Ninject configuration in Application Configuration file.

Sample app.config:

<pre><code>
&lt;?xml version="1.0" encoding="utf-8" ?&gt;
&lt;configuration&gt;
  &lt;configSections&gt;
    &lt;section name="ninject" type="Ninject.Extensions.Xml.Configuration.NinjectSectionHandler, Ninject.Extensions.Xml" /&gt;
  &lt;/configSections&gt;
  &lt;ninject&gt;
    &lt;module name="basicTest"&gt;
      &lt;bind name="melee"
                  service="ConsoleApplication1.IWeapon, ConsoleApplication1"
                  to="ConsoleApplication1.Sword, ConsoleApplication1" /&gt;
      &lt;bind name="range"
                  service="ConsoleApplication1.IWeapon, ConsoleApplication1"
                  to="ConsoleApplication1.Shuriken, ConsoleApplication1" /&gt;
    &lt;/module&gt;
  &lt;/ninject&gt;
&lt;/configuration&gt;
</code></pre>


Ninject kernel configuration:

<pre><code>
var kernel = new StandardKernel();
kernel.LoadFromConfiguration("ninject");
</code></pre>


I have tested this code with .NET 4.5 and Mono 3.12.0 (Windows).
